### PR TITLE
Update setup_frappe.sh

### DIFF
--- a/install_scripts/setup_frappe.sh
+++ b/install_scripts/setup_frappe.sh
@@ -137,7 +137,8 @@ add_debian_mariadb_repo() {
 	run_cmd sudo apt-get update
 	run_cmd sudo apt-get install -y software-properties-common python-software-properties
 	run_cmd sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db
-	if [ -z $(apt-cache search --names-only 'mariadb-server') ]; then
+	$repo_test=$(apt-cache search --names-only 'mariadb-server')
+	if [ -z "$repo_test" ]; then
 		run_cmd sudo add-apt-repository "deb http://ams2.mirrors.digitalocean.com/mariadb/repo/10.0/debian $CODENAME main"
 	fi
 }


### PR DESCRIPTION
Check for mariadb in existing repo

Without this check, setup script will fail in jessie 8.5
